### PR TITLE
fixes #8702 - adding ssh key pair integration for digital ocean

### DIFF
--- a/app/models/foreman_digitalocean/digitalocean.rb
+++ b/app/models/foreman_digitalocean/digitalocean.rb
@@ -6,6 +6,10 @@ module ForemanDigitalocean
     validates :user, :password, :presence => true
     before_create :test_connection
 
+    after_create :setup_key_pair
+    after_destroy :destroy_key_pair
+
+
     # Not sure why it would need a url, but OK (copied from ec2)
     alias_attribute :region, :url
 
@@ -32,6 +36,7 @@ module ForemanDigitalocean
     end
 
     def create_vm(args = { })
+      args["ssh_keys"] = [ssh_key] if ssh_key
       super(args)
     rescue Fog::Errors::Error => e
       logger.error "Unhandled DigitalOcean error: #{e.class}:#{e.message}\n " + e.backtrace.join("\n ")
@@ -99,6 +104,53 @@ module ForemanDigitalocean
       super.merge(
         :flavor_id => client.flavors.first.id
       )
+    end
+
+
+    # this method creates a new key pair for each new DigitalOcean compute resource
+    # it should create the key and upload it to DigitalOcean
+    def setup_key_pair
+      public_key, private_key = generate_key
+      key_name = "foreman-#{id}#{Foreman.uuid}"
+      key = client.create_ssh_key key_name, public_key
+      KeyPair.create! :name => key_name, :compute_resource_id => self.id, :secret => private_key
+    rescue => e
+      logger.warn "failed to generate key pair"
+      logger.error e.message
+      logger.error e.backtrace.join("\n")
+      destroy_key_pair
+      raise
+    end
+
+    def destroy_key_pair
+      return unless key_pair
+      logger.info "removing DigitalOcean key #{key_pair.name}"
+      client.destroy_ssh_key(ssh_key.id) if ssh_key
+      key_pair.destroy
+      true
+    rescue => e
+      logger.warn "failed to delete key pair from DigitalOcean, you might need to cleanup manually : #{e}"
+    end
+
+    def ssh_key
+      @ssh_key ||= begin
+        key = client.list_ssh_keys.data[:body]["ssh_keys"].select{|i| i["name"] == key_pair.name}.first
+        if key
+          #the vm creator expects objects which respond to id, OpenStruct is the shortest solution.
+          OpenStruct.new(key)
+        else
+          nil
+        end
+      end
+    end
+
+    def generate_key
+      key = OpenSSL::PKey::RSA.new 2048
+      type = key.ssh_type
+      data = [ key.to_blob ].pack('m0')
+
+      openssh_format_public_key = "#{type} #{data}"
+      [openssh_format_public_key, key.to_pem]
     end
 
   end


### PR DESCRIPTION
please do mind that this requires the user to put their SSH public keys into the machine using their config management tool after booting the machine, just like in EC2, otherwise, there won't really be any access to the machine (unless you get the private key from the DB)

Also, and this is critical - the configuration management should remove that key from the authorized_keys for root! the private key is stored as cleartext on the DB, and should only be used to boot the machine and start up the config management, be it puppet, chef or whatever else the user chooses to use. (that's a general comment, correct for DO, EC2 and OpenStack)
