### PR TITLE
Need to require 'date' from stdlib

### DIFF
--- a/foreman-digitalocean.gemspec
+++ b/foreman-digitalocean.gemspec
@@ -2,6 +2,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 # Maintain your gem's version:
 require 'foreman_digitalocean/version'
+require 'date'
 
 # Describe your gem and declare its dependencies:
 Gem::Specification.new do |s|


### PR DESCRIPTION
Failure to require `date` leads to an undefined method error when installing.
