### PR TITLE
Fixes #8650 - VM tab should show region name

### DIFF
--- a/app/models/concerns/fog_extensions/digitalocean/server.rb
+++ b/app/models/concerns/fog_extensions/digitalocean/server.rb
@@ -16,14 +16,28 @@ module FogExtensions
         @flavor ||= service.flavors.get(flavor_id.to_i)
       end
 
+      def flavor_name
+        requires :flavor
+        @flavor_name ||= @flavor.try(:name)
+      end
+
       def image
         requires :image_id
         @image ||= service.images.get(image_id.to_i)
       end
 
+      def image_name
+        @image_name ||= @image.try(:name)
+      end
+
       def region
         requires :region_id
         @region ||= service.regions.get(region_id.to_i)
+      end
+
+      def region_name
+        requires :region
+        @region_name ||= @region.try(:name)
       end
 
       def ip_addresses

--- a/app/views/compute_resources_vms/show/_digitalocean.html.erb
+++ b/app/views/compute_resources_vms/show/_digitalocean.html.erb
@@ -6,9 +6,8 @@
     <%= prop :private_ip_address %>
     <%= prop :state %>
     <%= prop :created_at, 'Created' %>
-    <%= prop :image_id, 'Image ID' %>
-    <%= prop @vm.image.name, 'Image' if @vm.image.present? %>
-    <%= prop :flavor_id, 'Flavor ID' %>
-    <%= prop :vm_description, "Type (flavor)" %>
+    <%= prop :image_name, 'Image' if @vm.image.present? %>
+    <%= prop :flavor_name, "Type (flavor)" %>
+    <%= prop :region_name, "Region" %>
   </table>
 </div>


### PR DESCRIPTION
* Added several _name methods to server which removes the "logic" from the views
* Fixed several of the "ID" displays to show the "name" instead
* Added region_name

NOTE: It is *unfortunate* that both Foreman and Fog use "images" to describe the
same thing. The "Image" will only appear if it matches an existing *foreman*
image. That is probably another bug for another time. :)