### PR TITLE
Refs #15961 - Remove attr_accessible from tests

### DIFF
--- a/lib/foreman_digitalocean/tasks/test.rake
+++ b/lib/foreman_digitalocean/tasks/test.rake
@@ -8,6 +8,7 @@ namespace :test do
         "#{ForemanDigitalocean::Engine.root}/test/**/*_test.rb"
       ]
       t.verbose = true
+      t.warning = false
     end
 
     Rake::Task[test_task.name].invoke

--- a/test/unit/foreman_digitalocean/digitalocean_test.rb
+++ b/test/unit/foreman_digitalocean/digitalocean_test.rb
@@ -2,8 +2,6 @@ require 'test_plugin_helper'
 
 class ForemanDigitalocean::DigitaloceanTest < ActiveSupport::TestCase
   should validate_presence_of(:api_key)
-  should allow_mass_assignment_of(:region)
-  should allow_mass_assignment_of(:api_key)
   should delegate_method(:flavors).to(:client)
   should have_one(:key_pair)
 


### PR DESCRIPTION
Currently tests check for attr_accessible of some attributes. I remove
that and also removed the rake task warnings (it's way too verbose)