### PR TITLE
Fixes #16071 - New/edit compute resource doesn't remove API_key

### DIFF
--- a/app/views/compute_resources/form/_digitalocean.html.erb
+++ b/app/views/compute_resources/form/_digitalocean.html.erb
@@ -1,14 +1,12 @@
-<%= password_f f, :api_key, :label => _("API Key"), :unset => unset_password? %>
+<%= password_f f, :password, :label => _("API Key"), :unset => unset_password? %>
 <% regions = f.object.regions rescue [] %>
 
 <div id='region_selection'>
-  <%= select_f(
-    f, :region, regions, :slug, :name, {},
+  <%= selectable_f(f, :region, regions.map(&:slug), {},
     :label => _('Default Region'), :disabled => regions.empty?,
     :help_inline => link_to_function(
       regions.empty? ? _("Load Regions") : _("Test Connection"), "testConnection(this)",
       :class => "btn + #{regions.empty? ? "btn-default" : "btn-success"}",
       :'data-url' => test_connection_compute_resources_path) +
-     spinner('', :id => 'test_connection_indicator',
-             :class => 'hide').html_safe) %>
+     hidden_spinner('', :id => 'test_connection_indicator').html_safe) %>
 </div>

--- a/foreman-digitalocean.gemspec
+++ b/foreman-digitalocean.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_development_dependency 'rubocop', '~> 0.26'
+  s.add_development_dependency 'rubocop', '~> 0.42'
 end

--- a/test/unit/foreman_digitalocean/digitalocean_test.rb
+++ b/test/unit/foreman_digitalocean/digitalocean_test.rb
@@ -1,16 +1,17 @@
 require 'test_plugin_helper'
 
-class ForemanDigitalocean::DigitaloceanTest < ActiveSupport::TestCase
-  should validate_presence_of(:api_key)
-  should delegate_method(:flavors).to(:client)
-  should have_one(:key_pair)
+module ForemanDigitalocean
+  class DigitaloceanTest < ActiveSupport::TestCase
+    should validate_presence_of(:api_key)
+    should have_one(:key_pair)
 
-  setup { Fog.mock! }
-  teardown { Fog.unmock! }
+    setup { Fog.mock! }
+    teardown { Fog.unmock! }
 
-  test 'ssh key pair gets created after its saved' do
-    digitalocean = FactoryGirl.build(:digitalocean_cr)
-    digitalocean.expects(:setup_key_pair)
-    digitalocean.save
+    test 'ssh key pair gets created after its saved' do
+      digitalocean = FactoryGirl.build(:digitalocean_cr)
+      digitalocean.expects(:setup_key_pair)
+      digitalocean.save
+    end
   end
 end


### PR DESCRIPTION
The 'unset' field depends on core on 'password' in order to not remove
it and set a placeholder. It could be fixed there to be more flexible
but since we're using alias_attribute api_key, password this is fine.