### PR TITLE
fixes #19616 - use fog-digitalocean gem

### DIFF
--- a/app/models/concerns/fog_extensions/digitalocean/image.rb
+++ b/app/models/concerns/fog_extensions/digitalocean/image.rb
@@ -1,5 +1,5 @@
 module FogExtensions
-  module DigitalOcean
+  module Digitalocean
     module Image
       extend ActiveSupport::Concern
 

--- a/app/models/concerns/fog_extensions/digitalocean/server.rb
+++ b/app/models/concerns/fog_extensions/digitalocean/server.rb
@@ -1,5 +1,5 @@
 module FogExtensions
-  module DigitalOcean
+  module Digitalocean
     module Server
       extend ActiveSupport::Concern
 

--- a/app/models/foreman_digitalocean/digitalocean.rb
+++ b/app/models/foreman_digitalocean/digitalocean.rb
@@ -104,7 +104,6 @@ module ForemanDigitalocean
     def client
       @client ||= Fog::Compute.new(
         :provider => "DigitalOcean",
-        :version => 'V2',
         :digitalocean_token => api_key
       )
     end

--- a/foreman-digitalocean.gemspec
+++ b/foreman-digitalocean.gemspec
@@ -19,5 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
+  s.add_dependency 'fog-digitalocean', '~> 0.3'
+
   s.add_development_dependency 'rubocop', '~> 0.42'
 end

--- a/lib/foreman_digitalocean/engine.rb
+++ b/lib/foreman_digitalocean/engine.rb
@@ -16,7 +16,7 @@ module ForemanDigitalocean
 
     initializer 'foreman_digitalocean.register_plugin', :before => :finisher_hook do
       Foreman::Plugin.register :foreman_digitalocean do
-        requires_foreman '>= 1.8'
+        requires_foreman '>= 1.16'
         compute_resource ForemanDigitalocean::Digitalocean
         parameter_filter ComputeResource, :region, :api_key
       end
@@ -28,20 +28,14 @@ module ForemanDigitalocean
 
     config.to_prepare do
       require 'fog/digitalocean'
-      require 'fog/digitalocean/compute_v2'
-      require 'fog/digitalocean/models/compute_v2/image'
-      require 'fog/digitalocean/models/compute_v2/server'
-      require File.expand_path(
-        '../../../app/models/concerns/fog_extensions/digitalocean/server',
-        __FILE__)
-      require File.expand_path(
-        '../../../app/models/concerns/fog_extensions/digitalocean/image',
-        __FILE__)
+      require 'fog/digitalocean/compute'
+      require 'fog/digitalocean/models/compute/image'
+      require 'fog/digitalocean/models/compute/server'
 
-      Fog::Compute::DigitalOceanV2::Image.send :include,
-        FogExtensions::DigitalOcean::Image
-      Fog::Compute::DigitalOceanV2::Server.send :include,
-        FogExtensions::DigitalOcean::Server
+      Fog::Compute::DigitalOcean::Image.send :include,
+        FogExtensions::Digitalocean::Image
+      Fog::Compute::DigitalOcean::Server.send :include,
+        FogExtensions::Digitalocean::Server
       ::Host::Managed.send :include,
         ForemanDigitalocean::Concerns::HostManagedExtensions
     end


### PR DESCRIPTION
For compatibility with Foreman 1.16.0+. The plugin's major version number should probably be incremented on release.

~~~A second commit~~~ The second part also tidies up the module names used in the Fog extensions so the Rails autoloader will work instead of using `require`.